### PR TITLE
removing erroneous extra paragraph between <div>'s

### DIFF
--- a/_projects/abstract.md
+++ b/_projects/abstract.md
@@ -7,7 +7,6 @@ featured_image: 'images/works/2017 - Collecting Thoughts and Pieces.jpg'
 ---
 
 <div class="gallery" data-columns="3">
-
 	<img src="/images/works/2016 - Abstract 1.jpg">
 	<img src="/images/works/2016 - Ice.png">
 	<img src="/images/works/2016 - Katie and Doug.JPG">
@@ -46,5 +45,4 @@ featured_image: 'images/works/2017 - Collecting Thoughts and Pieces.jpg'
 	<img src="/images/works/2019 - Triumph aka Collage Series 9.JPG">
 	<img src="/images/works/2019 - Untitled 2.jpg">
 	<img src="/images/works/2019 - Untitled.jpg">
-
 </div>

--- a/_projects/figurative.md
+++ b/_projects/figurative.md
@@ -7,7 +7,6 @@ featured_image: '/images/works/2006 - Annie.jpg'
 ---
 
 <div class="gallery" data-columns="3">
-
 	<img src="/images/works/2006 - Annie.jpg">
 	<img src="/images/works/2008 - Blue Aspen Trees.jpg">
 	<img src="/images/works/2009 - Self as Chuck Charcoal.jpg">
@@ -36,5 +35,4 @@ featured_image: '/images/works/2006 - Annie.jpg'
 	<img src="/images/works/2015 - Annie in Collage 2.jpg">
 	<img src="/images/works/2015 - Sam in Collage.JPG">
 	<img src="/images/works/2015 - Sam in Watercolor.jpg">
-
 </div>

--- a/_projects/selected.md
+++ b/_projects/selected.md
@@ -7,7 +7,6 @@ featured_image: '/images/works/2017 - Flight.jpg'
 ---
 
 <div class="gallery" data-columns="3">
-
 	<img src="/images/works/2016 - Abstract 1.jpg">
 	<img src="/images/works/2008 - Blue Aspen Trees.jpg">
 	<img src="/images/works/2017 - Flight.jpg">
@@ -21,7 +20,6 @@ featured_image: '/images/works/2017 - Flight.jpg'
 	<img src="/images/works/2019 - Green Crown.jpg">
 	<img src="/images/works/2018 - Yellow Whee.jpg">
 	<img src="/images/works/2018 - Green Whees.jpg">
-
 	<img src="/images/works/2019 - Original Dots.jpg">
 	<img src="/images/works/2006 - Annie.jpg">
 </div>


### PR DESCRIPTION
Image galleries were broken b/c had an extra line break after <div> and before </div>s. Removed to fix.